### PR TITLE
Renaming class

### DIFF
--- a/src/test/java/projectI/LexerTest.java
+++ b/src/test/java/projectI/LexerTest.java
@@ -10,13 +10,13 @@ import java.nio.file.Path;
 
 import static org.junit.Assert.assertArrayEquals;
 
-public class LexerTests extends TestCase {
-    public LexerTests(String testName) {
+public class LexerTest extends TestCase {
+    public LexerTest(String testName) {
         super(testName);
     }
 
     public static Test suite() {
-        return new TestSuite(LexerTests.class);
+        return new TestSuite(LexerTest.class);
     }
 
     private Lexer lexer;


### PR DESCRIPTION
Renamed `LexerTests` class to `LexerTest`. 
In this case, `mvn test` works without any additional parameters such as `-Dtest=LexerTests `